### PR TITLE
Actualizado

### DIFF
--- a/Level 4/rostring/rostring.c
+++ b/Level 4/rostring/rostring.c
@@ -7,7 +7,8 @@ int main(int argc, char **argv)
     int end;
     int flag;
 
-    if (argc > 1 && av[1][0])
+    flag = 0;
+    if (argc > 1 && argv[1][0])
     {
         i = 0;
         while (argv[1][i] == ' ' || argv[1][i] == '\t')


### PR DESCRIPTION
el nombre de la variable argv en linea 11 no estaba completo, tambien he inicializado la variable flag , ya que si no al recibir como parametro solo una palabra imprimia un espacio en blanco antes de la palabra