### PR TITLE
Add case if table is empty

### DIFF
--- a/Level 2/max/max.c
+++ b/Level 2/max/max.c
@@ -1,5 +1,8 @@
 int max(int *tab, unsigned int len)
 {
+	if (len == 0)
+		return (0);
+	
 	unsigned int result;
 	unsigned int i = 0;
 	


### PR DESCRIPTION
The subject specifies that if the array is empty, the function must return 0, but this is not currently the case. Don't forget that functions have indefinite behavior!