### PR TITLE
Managing the number of arguments in main

### DIFF
--- a/Level 3/add_prime_sum/add_prime_sum.c
+++ b/Level 3/add_prime_sum/add_prime_sum.c
@@ -35,7 +35,9 @@ void	put_nbr(int n)
 int main(int ac, char **av)
 {
 
-	if (ac == 2)
+    if (ac < 2)
+        write(1, "0", 1);
+	else if (ac == 2)
 	{
 		int	nbr = ft_atoi(av[1]);
 		int	sum = 0;
@@ -48,6 +50,7 @@ int main(int ac, char **av)
 		}
 		put_nbr(sum);
 	}
-	write(1, "\n", 1);
-	return (0);
+    else if (ac > 2)
+	    write(1, "0", 1);
+    write(1, "\n", 1);
 }


### PR DESCRIPTION
Currently, if the number of arguments was equal to 0, it would return an \n only, instead of a 0 followed by an \n. And, if the number of arguments was > 2 it did the calculation instead of returning 0 followed by an \n.