### PR TITLE
Fixed case where ft_rrange wasnt working correctly for start > end

### DIFF
--- a/Level 3/ft_rrange/ft_rrange.c
+++ b/Level 3/ft_rrange/ft_rrange.c
@@ -4,17 +4,22 @@ int *ft_rrange(int start, int end)
 {
 	int *range;
 	int i = 0;
-	int n = end - start + 1;
+	int step = 1;
+	int n = end - start;
 
-	if (start > end)
-		return (ft_rrange(end, start));
+	if (n < 0)
+		(n *= -1);
+	n++;
+
 	range = (int *)malloc(sizeof(int) * n);
 	if (range)
 	{
+		if (start < end)
+			step = -1;
 		while (i < n)
 		{
 			range[i] = end;
-			end--;
+			end = end + step;
 			i++;
 		}
 	}


### PR DESCRIPTION
Now correctly returns arr starting at end and ending at start for each case.
Inspired by approach from grademe.fr