### PR TITLE
Patch max.c

### DIFF
--- a/Level 2/max/max.c
+++ b/Level 2/max/max.c
@@ -3,7 +3,7 @@ int max(int *tab, unsigned int len)
 	if (len == 0)
 		return (0);
 	
-	unsigned int result;
+	int result;
 	unsigned int i = 0;
 	
 	result = tab[i];


### PR DESCRIPTION
type of var result should match the output type of the function (int), otherwise it might fail some tests.

**Example fail:** 
max( {-42;0;-5;-64;-2;-68;-1} , 7) <- here, instead of returning 0, current version of a function returns random wrong value.

**Why does it happen?**
_unsigned int_ can only represent _non-negative_ numbers. If you try to store a negative number in an unsigned int variable, it will actually store a large positive number due to **underflow**.
In above mentioned case, when result was an unsigned int and we assigned it a negative value from the array (e.g., result = tab[i]; where tab[i] is -42), result would not actually hold -42. Instead, it would hold a large positive value due to underflow.
