### PR TITLE
Update ft_strpbrk.c

### DIFF
--- a/Level 2/ft_strpbrk/ft_strpbrk.c
+++ b/Level 2/ft_strpbrk/ft_strpbrk.c
@@ -18,5 +18,5 @@ char *ft_strpbrk(const char *s1, const char *s2)
 		}
 		s1++;	
 	}
-	return (0);
+	return (NULL);
 }


### PR DESCRIPTION
Since the return value is a char 

instead of 0 it should be NULL according to man page


RETURN VALUES
     The strpbrk() function return a pointer to the first occurence of any character
     in the string,if no characters occur anywhere in s, strpbrk() returns NULL.