### PR TITLE
Update epur_str.c

### DIFF
--- a/Level 3/epur_str/epur_str.c
+++ b/Level 3/epur_str/epur_str.c
@@ -7,6 +7,7 @@ int main(int argc, char const *argv[])
 
 	if (argc == 2)
 	{
+		flg = 0;
 		i = 0;
 		while (argv[1][i] == ' ' || argv[1][i] == '\t')
 			i += 1;


### PR DESCRIPTION
the variable "flg" is being implicitly initialized in the first iteration of the loop, which causes unexpected behavior that is not removing spaces and tabs from the beginning of the string. Need to explicitly initialize it to 0 before entering the loop.